### PR TITLE
Update manifest file to exclude Javascript directory

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,4 +1,3 @@
 //= link_tree ../images
-//= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css
 


### PR DESCRIPTION
Rails uses Sprockets to precompile assets (JS, CSS, images, etc.).
In our app’s file:

app/assets/config/manifest.js

We have directories like this:
```
//= link_tree ../images
//= link_directory ../javascripts .js
//= link_directory ../stylesheets .css
```

Sprockets is complaining because javascript directory doesn’t exist in the Docker build context so it fails when it tries to link it. 